### PR TITLE
Disks now only need autoDelete to be specified True at either

### DIFF
--- a/compress/README.md
+++ b/compress/README.md
@@ -88,7 +88,7 @@ Operation complete
                                                   u'logging': { u'gcsPath': u'gs://YOUR-BUCKET/pipelines-api-examples/compress/logging'},
                                                   u'outputs': { u'outputFile': u'gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12877_S1.genome.vcf.gz'},
                                                   u'projectId': u'YOUR-PROJECT-ID',
-                                                  u'resources': { u'disks': [ { u'autoDelete': True,
+                                                  u'resources': { u'disks': [ { u'autoDelete': False,
                                                                                 u'mountPoint': u'',
                                                                                 u'name': u'data',
                                                                                 u'readOnly': False,

--- a/compress/run_gzip.py
+++ b/compress/run_gzip.py
@@ -155,7 +155,6 @@ operation = service.pipelines().run(body={
       # For the data disk, specify the type and size
       'disks': [ {
         'name': 'datadisk',
-        'autoDelete': True,
 
         'sizeGb': args.disk_size,
       } ]

--- a/fastqc/README.md
+++ b/fastqc/README.md
@@ -124,7 +124,7 @@ Operation complete
                                                   u'logging': { u'gcsPath': u'gs://YOUR-BUCKET/pipelines-api-examples/fastqc/logging'},
                                                   u'outputs': { u'outputPath': u'gs://YOUR-BUCKET/pipelines-api-examples/fastqc/output'},
                                                   u'projectId': u'YOUR-PROJECT-ID',
-                                                  u'resources': { u'disks': [ { u'autoDelete': True,
+                                                  u'resources': { u'disks': [ { u'autoDelete': False,
                                                                                 u'mountPoint': u'',
                                                                                 u'name': u'datadisk',
                                                                                 u'readOnly': False,

--- a/fastqc/cloud/run_fastqc.py
+++ b/fastqc/cloud/run_fastqc.py
@@ -191,7 +191,6 @@ operation = service.pipelines().run(body={
       # For the data disk, specify the type and size
       'disks': [ {
         'name': 'datadisk',
-        'autoDelete': True,
 
         'sizeGb': args.disk_size,
       } ]

--- a/set_vcf_sample_id/README.md
+++ b/set_vcf_sample_id/README.md
@@ -133,7 +133,7 @@ Operation complete
                                                   u'outputs': { u'outputPath': u'gs://YOUR-BUCKET/pipelines-api-examples/set_vcf_sample_id/output'},
                                                   u'projectId': u'YOUR-PROJECT-ID',
                                                   u'resources': { u'bootDiskSizeGb': 0,
-                                                                  u'disks': [ { u'autoDelete': True,
+                                                                  u'disks': [ { u'autoDelete': False,
                                                                                 u'mountPoint': u'',
                                                                                 u'name': u'datadisk',
                                                                                 u'readOnly': False,

--- a/set_vcf_sample_id/cloud/run_set_vcf_sample_id.py
+++ b/set_vcf_sample_id/cloud/run_set_vcf_sample_id.py
@@ -196,7 +196,6 @@ operation = service.pipelines().run(body={
       # For the data disk, specify the type and size
       'disks': [ {
         'name': 'datadisk',
-        'autoDelete': True,
 
         'sizeGb': args.disk_size,
       } ]


### PR DESCRIPTION
pipeline create or run but not both.
Updated compress, fastqc, and set_vcf_sample_id examples.