### PR TITLE
Update the compress example to include decompression

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can do the packaging to Docker yourself, or use existing Docker images.
 
 ## Examples
 
-* [Compress a file](./compress)
+* [Compress or Decompress files](./compress)
 * [Run FastQC over a list of BAM or FASTQ files](./fastqc)
 * [Use samtools to create a BAM index file](./samtools)
 * [Use a custom script in Cloud Storage to update a VCF header](./set_vcf_sample_id)

--- a/compress/README.md
+++ b/compress/README.md
@@ -1,11 +1,12 @@
-# Compress a file from Cloud Storage
+# Compress or Decompress files from Cloud Storage
 
-This pipeline provides the use-case of downloading a file from Cloud Storage,
-compressing it via gzip, and pushing the result to Cloud Storage.
-The gzip command is provided as part of the default `ubuntu` image.
+This pipeline provides the use-case of downloading one or more files
+from Cloud Storage, compressing or decompressing it (via gzip, gunzip,
+bzip2, or bunzip2) and pushing the result to Cloud Storage.
 
 This pipeline does not involve packaging a custom Docker image, and
 thus there is no requirement to install Docker on your local machine.
+The gzip and bzip2 commands are provided as part of the default `ubuntu` image.
 
 ## (1) Run the pipeline in the cloud
 
@@ -17,9 +18,10 @@ PYTHONPATH=.. python ./run_gzip.py \
   --project YOUR-PROJECT-ID \
   --zones "us-*" \
   --disk-size 200 \
-  --input gs://genomics-public-data/platinum-genomes/vcf/NA12877_S1.genome.vcf \
-  --output gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12877_S1.genome.vcf.gz \
-  --logging gs://YOUR-BUCKET/pipelines-api-examples/compress/logging\
+  --operation "gunzip" \
+  --input gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/working/20140123_NA12878_Illumina_Platinum/**.vcf.gz \
+  --output gs://YOUR-BUCKET/pipelines-api-examples/compress/output \
+  --logging gs://YOUR-BUCKET/pipelines-api-examples/compress/logging \
   --poll-interval 20
 ```
 
@@ -37,7 +39,7 @@ be emitted.
 { u'done': False,
   u'metadata': { u'@type': u'type.googleapis.com/google.genomics.v1.OperationMetadata',
                  u'clientId': u'',
-                 u'createTime': u'2016-03-10T04:53:28.000Z',
+                 u'createTime': u'2016-03-30T17:34:08.000Z',
                  u'events': [],
                  u'projectId': u'YOUR-PROJECT-ID'},
   u'name': u'operations/YOUR-NEW-OPERATION-ID'}
@@ -47,56 +49,54 @@ Operation not complete. Sleeping 20 seconds
 Operation not complete. Sleeping 20 seconds
 ...
 Operation not complete. Sleeping 20 seconds
+
 Operation complete
 
 { u'done': True,
   u'metadata': { u'@type': u'type.googleapis.com/google.genomics.v1.OperationMetadata',
                  u'clientId': u'',
-                 u'createTime': u'2016-03-10T04:53:28.000Z',
-                 u'endTime': u'2016-03-10T05:08:10.000Z',
-                 u'events': [ { u'description': u'start(g1-small)',
-                                u'startTime': u'2016-03-10T04:54:44.000Z'},
+                 u'createTime': u'2016-03-30T17:34:08.000Z',
+                 u'endTime': u'2016-03-30T17:36:11.000Z',
+                 u'events': [ { u'description': u'start',
+                                u'startTime': u'2016-03-30T17:35:34.244369759Z'},
                               { u'description': u'pulling-image',
-                                u'startTime': u'2016-03-10T04:54:53.000Z'},
+                                u'startTime': u'2016-03-30T17:35:34.244435642Z'},
                               { u'description': u'localizing-files',
-                                u'startTime': u'2016-03-10T04:55:29.000Z'},
+                                u'startTime': u'2016-03-30T17:35:44.884961352Z'},
                               { u'description': u'running-docker',
-                                u'startTime': u'2016-03-10T04:58:58.000Z'},
+                                u'startTime': u'2016-03-30T17:35:50.872211301Z'},
                               { u'description': u'delocalizing-files',
-                                u'startTime': u'2016-03-10T05:07:31.000Z'},
+                                u'startTime': u'2016-03-30T17:35:58.234466119Z'},
                               { u'description': u'ok',
-                                u'startTime': u'2016-03-10T05:08:05.000Z'}],
+                                u'startTime': u'2016-03-30T17:36:11.404718158Z'}],
                  u'projectId': u'YOUR-PROJECT-ID',
                  u'request': { u'@type': u'type.googleapis.com/google.genomics.v1alpha2.RunPipelineRequest',
-                               u'ephemeralPipeline': { u'description': u'Run "gzip" on a file',
-                                                       u'docker': { u'cmd': u'gzip /mnt/data/my_file',
+                               u'ephemeralPipeline': { u'description': u'Compress or decompress a file',
+                                                       u'docker': { u'cmd': u'cd /mnt/data/workspace && for file in $(/bin/ls); do gunzip ${file}; done',
                                                                     u'imageName': u'ubuntu'},
                                                        u'name': u'compress',
-                                                       u'parameters': [ { u'description': u'Cloud Storage path to an uncompressed file',
-                                                                          u'name': u'inputFile'},
-                                                                        { u'description': u'Cloud Storage path for where to write the compressed result',
-                                                                          u'name': u'outputFile'}],
+                                                       u'parameters': [ { u'description': u'Cloud Storage path to an input file',
+                                                                          u'name': u'inputFile0'},
+                                                                        { u'description': u'Cloud Storage path for where to FastQC output',
+                                                                          u'name': u'outputPath'}],
                                                        u'projectId': u'YOUR-PROJECT-ID',
                                                        u'resources': { u'disks': [ { u'autoDelete': True,
-                                                                                     u'name': u'data',
-                                                                                     u'sizeGb': 500,
-                                                                                     u'type': u'PERSISTENT_HDD'}],
-                                                                       u'minimumCpuCores': 1,
-                                                                       u'minimumRamGb': 3.75}},
+                                                                                     u'name': u'datadisk'}]}},
                                u'pipelineArgs': { u'clientId': u'',
-                                                  u'inputs': { u'inputFile': u'gs://genomics-public-data/platinum-genomes/vcf/NA12877_S1.genome.vcf'},
+                                                  u'inputs': { u'inputFile0': u'gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/technical/working/20140123_NA12878_Illumina_Platinum/**.vcf.gz'},
                                                   u'logging': { u'gcsPath': u'gs://YOUR-BUCKET/pipelines-api-examples/compress/logging'},
-                                                  u'outputs': { u'outputFile': u'gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12877_S1.genome.vcf.gz'},
+                                                  u'outputs': { u'outputPath': u'gs://YOUR-BUCKET/pipelines-api-examples/compress/output'},
                                                   u'projectId': u'YOUR-PROJECT-ID',
-                                                  u'resources': { u'disks': [ { u'autoDelete': False,
+                                                  u'resources': { u'bootDiskSizeGb': 0,
+                                                                  u'disks': [ { u'autoDelete': False,
                                                                                 u'mountPoint': u'',
-                                                                                u'name': u'data',
+                                                                                u'name': u'datadisk',
                                                                                 u'readOnly': False,
                                                                                 u'sizeGb': 200,
                                                                                 u'source': u'',
-                                                                                u'type': u'PERSISTENT_HDD'}],
+                                                                                u'type': u'TYPE_UNSPECIFIED'}],
                                                                   u'minimumCpuCores': 0,
-                                                                  u'minimumRamGb': 1,
+                                                                  u'minimumRamGb': 0,
                                                                   u'preemptible': False,
                                                                   u'zones': [ u'us-central1-a',
                                                                               u'us-central1-b',
@@ -109,9 +109,8 @@ Operation complete
                                                                        u'scopes': [ u'https://www.googleapis.com/auth/compute',
                                                                                     u'https://www.googleapis.com/auth/devstorage.full_control',
                                                                                     u'https://www.googleapis.com/auth/genomics']}}},
-                 u'startTime': u'2016-03-10T04:53:57.000Z'},
+                 u'startTime': u'2016-03-30T17:34:36.000Z'},
   u'name': u'operations/YOUR-NEW-OPERATION-ID'}
-
 ```
 
 ## (2) Check the results
@@ -119,6 +118,11 @@ Operation complete
 Check the operation output for a top-level `errors` field.
 If none, then the operation should have finished successfully.
 
-Navigate to your bucket in the
-[Cloud Console](https://console.cloud.google.com/project/_/storage)
-to see the output and log files for the operation.
+```
+$ gsutil ls gs://YOUR-BUCKET/pipelines-api-examples/compress/output
+gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12878.wgs.illumina_platinum.20140122.indel.genotypes.vcf
+gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12878.wgs.illumina_platinum.20140122.snp.genotypes.vcf
+gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12878.wgs.illumina_platinum.20140404.indels_v2.vcf
+gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12878.wgs.illumina_platinum.20140404.snps_v2.vcf
+gs://YOUR-BUCKET/pipelines-api-examples/compress/output/NA12878.wgs.illumina_platinum.20140404.svs_v2.vcf
+```

--- a/compress/run_gzip.py
+++ b/compress/run_gzip.py
@@ -17,8 +17,8 @@
 
 """Python sample demonstrating use of the Google Genomics Pipelines API.
 
-This sample demonstrates running a pipeline to compress a file that is in
-Google Cloud Storage.
+This sample demonstrates running a pipeline to compress or decompress
+a file that is in Google Cloud Storage.
 
 This sample demonstrates running the pipeline in an "ephemeral" manner;
 no call to pipelines.create() is necessary. No pipeline is persisted
@@ -29,6 +29,7 @@ Usage:
       --project <project-id> \
       --zones <gce-zones> \
       --disk-size <size-in-gb> \
+      --operation <compression-operation> \
       --input <gcs-input-path> \
       --output <gcs-output-path> \
       --logging <gcs-logging-path> \
@@ -65,8 +66,11 @@ parser.add_argument("--disk-size", required=True, type=int,
                     help="Size (in GB) of disk for both input and output")
 parser.add_argument("--zones", required=True, nargs="+",
                     help="List of Google Compute Engine zones (supports wildcards)")
-parser.add_argument("--input", required=True,
-                    help="Cloud Storage path to input file")
+parser.add_argument("--operation", required=False, default="gzip",
+                    choices=[ "gzip", "gunzip", "bzip2", "bunzip2" ],
+                    help="Choice of compression/decompression command")
+parser.add_argument("--input", required=True, nargs="+",
+                    help="Cloud Storage path to input file(s)")
 parser.add_argument("--output", required=True,
                     help="Cloud Storage path to output file (with the .gz extension)")
 parser.add_argument("--logging", required=True,
@@ -90,7 +94,7 @@ operation = service.pipelines().run(body={
   'ephemeralPipeline' : {
     'projectId': args.project,
     'name': 'compress',
-    'description': 'Run "gzip" on a file',
+    'description': 'Compress or decompress a file',
 
     # Define the resources needed for this pipeline.
     'resources' : {
@@ -109,36 +113,57 @@ operation = service.pipelines().run(body={
 
     # Specify the docker image to use along with the command
     'docker' : {
-      'imageName': 'ubuntu', # Stock ubuntu contains the gzip command
+      'imageName': 'ubuntu', # Stock ubuntu contains the gzip, bzip2 commands
 
-      # Compress a file that will be downloaded from Cloud Storage to the data disk. 
-      # The local copy of the file will be named "my_file". See the inputParameters.
-      'cmd': 'gzip /mnt/data/my_file',
+      'cmd': ('cd /mnt/data/workspace && '
+              'for file in $(/bin/ls); do '
+                '%s ${file}; '
+              'done' % args.operation),
     },
 
-    # This example takes a single input parameter - a path to a Cloud Storage file to
-    # be copied to the data disk's mount point (/mnt/data) and name it to "my_file".
+    # The Pipelines API currently supports full GCS paths, along with patterns (globs),
+    # but it doesn't directly support a list of files being passed as a single input
+    # parameter ("gs://bucket/foo.bam gs://bucket/bar.bam").
     #
-    # The inputFile specified in the pipelineArgs (see below) specify the
-    # Cloud Storage path to copy to /mnt/data/my_file.
+    # We can simply generate a series of inputs (input0, input1, etc.) to support this here.
+    #
+    # 'inputParameters' : [ {
+    #   'name': 'inputFile0',
+    #   'description': 'Cloud Storage path to an input file',
+    #   'localCopy': {
+    #     'path': 'workspace/',
+    #     'disk': 'datadisk'
+    #   }
+    # }, {
+    #   'name': 'inputFile1',
+    #   'description': 'Cloud Storage path to an input file',
+    #   'localCopy': {
+    #     'path': 'workspace/',
+    #     'disk': 'datadisk'
+    #   }
+    # <etc>
+    # } ],
+
+    # The inputFile<n> specified in the pipelineArgs (see below) will specify the
+    # Cloud Storage path to copy to /mnt/data/workspace/.
+
     'inputParameters' : [ {
-      'name': 'inputFile',
-      'description': 'Cloud Storage path to an uncompressed file',
+      'name': 'inputFile%d' % idx,
+      'description': 'Cloud Storage path to an input file',
       'localCopy': {
-        'path': 'my_file',
+        'path': 'workspace/',
         'disk': 'datadisk'
       }
-    } ],
+    } for idx in range(len(args.input)) ],
 
-    # gzip compresses in-place, so the output file from gzip is my_file.gz.
     # By specifying an outputParameter, we instruct the pipelines API to
-    # copy /mnt/data/my_file.gz to the Cloud Storage location specified in
+    # copy /mnt/data/workspace/* to the Cloud Storage location specified in
     # the pipelineArgs (see below).
     'outputParameters' : [ {
-      'name': 'outputFile',
-      'description': 'Cloud Storage path for where to write the compressed result',
+      'name': 'outputPath',
+      'description': 'Cloud Storage path for where to FastQC output',
       'localCopy': {
-        'path': 'my_file.gz',
+        'path': 'workspace/*',
         'disk': 'datadisk'
       }
     } ]
@@ -160,16 +185,23 @@ operation = service.pipelines().run(body={
       } ]
     },
 
-    'inputs': {
-      # Pass the user-specified Cloud Storage path of the file to compress
-      'inputFile': args.input
+    # Pass the user-specified Cloud Storage paths as a map of input files
+    # 'inputs' : {
+    #   'inputFile0' : 'gs://bucket/foo.bam',
+    #   'inputFile1' : 'gs://bucket/bar.bam', 
+    #   <etc>
+    # }
+    'inputs' : {
+      'inputFile%d' % idx : value for idx, value in enumerate(args.input)
     },
+
+    # Pass the user-specified Cloud Storage destination path of output
     'outputs': {
-      # Pass the user-specified Cloud Storage destination path of the compressed file
-      'outputFile': args.output
+      'outputPath': args.output
     },
+
+    # Pass the user-specified Cloud Storage destination for pipeline logging
     'logging': {
-      # Pass the user-specified Cloud Storage destination for pipeline logging
       'gcsPath': args.logging
     },
   }
@@ -179,6 +211,7 @@ operation = service.pipelines().run(body={
 pp = pprint.PrettyPrinter(indent=2)
 pp.pprint(operation)
 
+# If requested - poll until the operation reaches completion state ("done: true")
 if args.poll_interval > 0:
   completed_op = poller.poll(service, operation, args.poll_interval)
   pp.pprint(completed_op)

--- a/compress/run_gzip.py
+++ b/compress/run_gzip.py
@@ -91,13 +91,13 @@ operation = service.pipelines().run(body={
   # There are some nuances in the API that are still being ironed out
   # to make this more compact.
 
-  'ephemeralPipeline' : {
+  'ephemeralPipeline': {
     'projectId': args.project,
     'name': 'compress',
     'description': 'Compress or decompress a file',
 
     # Define the resources needed for this pipeline.
-    'resources' : {
+    'resources': {
       # Create a data disk that is attached to the VM and destroyed when the
       # pipeline terminates.
       'disks': [ {
@@ -112,7 +112,7 @@ operation = service.pipelines().run(body={
     },
 
     # Specify the docker image to use along with the command
-    'docker' : {
+    'docker': {
       'imageName': 'ubuntu', # Stock ubuntu contains the gzip, bzip2 commands
 
       'cmd': ('cd /mnt/data/workspace && '
@@ -127,7 +127,7 @@ operation = service.pipelines().run(body={
     #
     # We can simply generate a series of inputs (input0, input1, etc.) to support this here.
     #
-    # 'inputParameters' : [ {
+    # 'inputParameters': [ {
     #   'name': 'inputFile0',
     #   'description': 'Cloud Storage path to an input file',
     #   'localCopy': {
@@ -147,7 +147,7 @@ operation = service.pipelines().run(body={
     # The inputFile<n> specified in the pipelineArgs (see below) will specify the
     # Cloud Storage path to copy to /mnt/data/workspace/.
 
-    'inputParameters' : [ {
+    'inputParameters': [ {
       'name': 'inputFile%d' % idx,
       'description': 'Cloud Storage path to an input file',
       'localCopy': {
@@ -159,7 +159,7 @@ operation = service.pipelines().run(body={
     # By specifying an outputParameter, we instruct the pipelines API to
     # copy /mnt/data/workspace/* to the Cloud Storage location specified in
     # the pipelineArgs (see below).
-    'outputParameters' : [ {
+    'outputParameters': [ {
       'name': 'outputPath',
       'description': 'Cloud Storage path for where to FastQC output',
       'localCopy': {
@@ -169,11 +169,11 @@ operation = service.pipelines().run(body={
     } ]
   },
 
-  'pipelineArgs' : {
+  'pipelineArgs': {
     'projectId': args.project,
 
     # Override the resources needed for this pipeline
-    'resources' : {
+    'resources': {
       # Expand any zone short-hand patterns
       'zones': defaults.get_zones(args.zones),
 
@@ -186,12 +186,12 @@ operation = service.pipelines().run(body={
     },
 
     # Pass the user-specified Cloud Storage paths as a map of input files
-    # 'inputs' : {
-    #   'inputFile0' : 'gs://bucket/foo.bam',
-    #   'inputFile1' : 'gs://bucket/bar.bam', 
+    # 'inputs': {
+    #   'inputFile0': 'gs://bucket/foo.bam',
+    #   'inputFile1': 'gs://bucket/bar.bam', 
     #   <etc>
     # }
-    'inputs' : {
+    'inputs': {
       'inputFile%d' % idx : value for idx, value in enumerate(args.input)
     },
 

--- a/fastqc/cloud/run_fastqc.py
+++ b/fastqc/cloud/run_fastqc.py
@@ -100,13 +100,13 @@ operation = service.pipelines().run(body={
   # There are some nuances in the API that are still being ironed out
   # to make this more compact.
 
-  'ephemeralPipeline' : {
+  'ephemeralPipeline': {
     'projectId': args.project,
     'name': 'fastqc',
     'description': 'Run "FastQC" on one or more files',
 
     # Define the resources needed for this pipeline.
-    'resources' : {
+    'resources': {
       # Create a data disk that is attached to the VM and destroyed when the
       # pipeline terminates.
       'disks': [ {
@@ -121,7 +121,7 @@ operation = service.pipelines().run(body={
     },
 
     # Specify the docker image to use along with the command
-    'docker' : {
+    'docker': {
       'imageName': 'gcr.io/%s/fastqc' % args.project,
 
       # The Pipelines API will create the input directory when localizing files,
@@ -136,7 +136,7 @@ operation = service.pipelines().run(body={
     #
     # We can simply generate a series of inputs (input0, input1, etc.) to support this here.
     #
-    # 'inputParameters' : [ {
+    # 'inputParameters': [ {
     #   'name': 'inputFile0',
     #   'description': 'Cloud Storage path to an input file',
     #   'localCopy': {
@@ -156,7 +156,7 @@ operation = service.pipelines().run(body={
     # The inputFile<n> specified in the pipelineArgs (see below) will specify the
     # Cloud Storage path to copy to /mnt/data/input/.
 
-    'inputParameters' : [ {
+    'inputParameters': [ {
       'name': 'inputFile%d' % idx,
       'description': 'Cloud Storage path to an input file',
       'localCopy': {
@@ -168,7 +168,7 @@ operation = service.pipelines().run(body={
     # By specifying an outputParameter, we instruct the pipelines API to
     # copy /mnt/data/output/* to the Cloud Storage location specified in
     # the pipelineArgs (see below).
-    'outputParameters' : [ {
+    'outputParameters': [ {
       'name': 'outputPath',
       'description': 'Cloud Storage path for where to FastQC output',
       'localCopy': {
@@ -178,11 +178,11 @@ operation = service.pipelines().run(body={
     } ]
   },
 
-  'pipelineArgs' : {
+  'pipelineArgs': {
     'projectId': args.project,
 
     # Override the resources needed for this pipeline
-    'resources' : {
+    'resources': {
       'minimumRamGb': 1, # For this example, override the 3.75 GB default
 
       # Expand any zone short-hand patterns
@@ -197,12 +197,12 @@ operation = service.pipelines().run(body={
     },
 
     # Pass the user-specified Cloud Storage paths as a map of input files
-    # 'inputs' : {
-    #   'inputFile0' : 'gs://bucket/foo.bam',
-    #   'inputFile1' : 'gs://bucket/bar.bam', 
+    # 'inputs': {
+    #   'inputFile0': 'gs://bucket/foo.bam',
+    #   'inputFile1': 'gs://bucket/bar.bam', 
     #   <etc>
     # }
-    'inputs' : {
+    'inputs': {
       'inputFile%d' % idx : value for idx, value in enumerate(args.input)
     },
 

--- a/fastqc/cloud/run_fastqc.py
+++ b/fastqc/cloud/run_fastqc.py
@@ -207,7 +207,7 @@ operation = service.pipelines().run(body={
     },
 
     # Pass the user-specified Cloud Storage destination path of the FastQC output
-    'outputs' : {
+    'outputs': {
       'outputPath': args.output
     },
 

--- a/set_vcf_sample_id/cloud/run_set_vcf_sample_id.py
+++ b/set_vcf_sample_id/cloud/run_set_vcf_sample_id.py
@@ -97,13 +97,13 @@ operation = service.pipelines().run(body={
   # There are some nuances in the API that are still being ironed out
   # to make this more compact.
 
-  'ephemeralPipeline' : {
+  'ephemeralPipeline': {
     'projectId': args.project,
     'name': 'set_vcf_sample_id',
     'description': 'Set the sample ID in a VCF header',
 
     # Define the resources needed for this pipeline.
-    'resources' : {
+    'resources': {
       # Create a data disk that is attached to the VM and destroyed when the
       # pipeline terminates.
       'disks': [ {
@@ -118,7 +118,7 @@ operation = service.pipelines().run(body={
     },
 
     # Specify the docker image to use along with the command
-    'docker' : {
+    'docker': {
       'imageName': 'python:2.7',
 
       # The Pipelines API will create the input directory when localizing files,
@@ -139,7 +139,7 @@ operation = service.pipelines().run(body={
     # The inputFile<n> specified in the pipelineArgs (see below) will
     # specify the Cloud Storage path to copy to /mnt/data/input/.
 
-    'inputParameters' : [ {
+    'inputParameters': [ {
       'name': 'inputFile%d' % idx,
       'description': 'Cloud Storage path to input file(s)',
       'localCopy': {
@@ -173,7 +173,7 @@ operation = service.pipelines().run(body={
     # By specifying an outputParameter, we instruct the pipelines API to
     # copy /mnt/data/output/* to the Cloud Storage location specified in
     # the pipelineArgs (see below).
-    'outputParameters' : [ {
+    'outputParameters': [ {
       'name': 'outputPath',
       'description': 'Cloud Storage path for where to copy the output',
       'localCopy': {
@@ -183,11 +183,11 @@ operation = service.pipelines().run(body={
     } ]
   },
 
-  'pipelineArgs' : {
+  'pipelineArgs': {
     'projectId': args.project,
 
     # Override the resources needed for this pipeline
-    'resources' : {
+    'resources': {
       'minimumRamGb': 1, # Shouldn't need the default 3.75 GB
 
       # Expand any zone short-hand patterns
@@ -203,19 +203,19 @@ operation = service.pipelines().run(body={
 
     # We can set a series of individual files, but typically usage will
     # just be:
-    # 'inputs' : {
-    #   'inputFile0' : 'gs://bucket/<sample>/*.vcf',
+    # 'inputs': {
+    #   'inputFile0': 'gs://bucket/<sample>/*.vcf',
     # }
-    'inputs' : dict( {
-      'inputFile%d' % idx : value for idx, value in enumerate(args.input)
+    'inputs': dict( {
+      'inputFile%d' % idx: value for idx, value in enumerate(args.input)
     }.items() + ({
-      'ORIGINAL_SAMPLE_ID' : args.original_sample_id,
+      'ORIGINAL_SAMPLE_ID': args.original_sample_id,
     }.items() if args.original_sample_id else []) + {
-      'NEW_SAMPLE_ID' : args.new_sample_id,
+      'NEW_SAMPLE_ID': args.new_sample_id,
     }.items()),
 
     # Pass the user-specified Cloud Storage destination path output
-    'outputs' : {
+    'outputs': {
       'outputPath': args.output
     },
 


### PR DESCRIPTION
Add support for gunzip, bzip2, bunzip2.
Make gunzip decompression the example (targeted use-case: decompress VCFs before import).
Also swept through the py files and corrected a style issue with spaces between dictionary keys and values.