### PR TITLE
When called without arguments, the usage instructions are returned

### DIFF
--- a/tools/poll.sh
+++ b/tools/poll.sh
@@ -1,3 +1,4 @@
+ls
 #!/bin/bash
 
 # Copyright 2016 Google Inc. All Rights Reserved.
@@ -50,7 +51,7 @@ readonly -f get_operation_all
 # MAIN
 
 # Check usage
-if [[ $# -ne 1 ]]; then
+if [[ $# -lt 1 ]]; then
   echo "Usage: $0 OPERATION-ID <poll-interval-seconds>"
   exit 1
 fi


### PR DESCRIPTION
Fixed argument check, now returning usage instructions only when no arguments are specified, thus enabling users to modify the polling interval via the second argument.