### PR TITLE
Add retries when polling Cromwell for job status.

### DIFF
--- a/wdl_runner/README.md
+++ b/wdl_runner/README.md
@@ -107,7 +107,7 @@ In this example, we push the container to
 via the following commands:
 
 ```
-docker tag -f ${USER}/wdl_runner gcr.io/YOUR-PROJECT-ID/wdl_runner
+docker tag ${USER}/wdl_runner gcr.io/YOUR-PROJECT-ID/wdl_runner
 gcloud docker push gcr.io/YOUR-PROJECT-ID/wdl_runner
 ```
 

--- a/wdl_runner/cromwell_launcher/cromwell_driver.py
+++ b/wdl_runner/cromwell_launcher/cromwell_driver.py
@@ -118,6 +118,7 @@ class CromwellDriver(object):
 
     # Poll Cromwell for job completion.
     attempt = 0
+    max_failed_attempts = 3
     while True:
       time.sleep(sleep_time)
 
@@ -131,7 +132,7 @@ class CromwellDriver(object):
         logging.info("Error polling Cromwell job status (attempt %d): %s",
           attempt, e)
 
-        if attempt >= 3:
+        if attempt >= max_failed_attempts:
           sys_util.exit_with_error(
             "Cromwell did not respond for %d consecutive requests" % attempt)
 

--- a/wdl_runner/cromwell_launcher/wdl_runner.py
+++ b/wdl_runner/cromwell_launcher/wdl_runner.py
@@ -166,7 +166,8 @@ def main():
   args.output_dir.rstrip('/')
 
   # Write logs at info level
-  logging.basicConfig(level=logging.INFO)
+  FORMAT = '%(asctime)-15s %(module)s %(levelname)s: %(message)s'
+  logging.basicConfig(level=logging.INFO, format=FORMAT)
 
   # Don't info-log every new connection to localhost, to keep stderr small.
   logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)


### PR DESCRIPTION
Giving up after one broken connection made long-running workflows fragile.

Improves logging output (format now includes timestamps and module name).
Adds a short wait before the first attempt to submit a job to Cromwell,
as it *always* failed and emitted a message before retrying.

Remove the use of the "-f" flag in "docker tag" in the README instructions.
The "-f" flag has been removed in docker v1.12.0.