### PR TITLE
wdl_runner: Add retries to setup.sh (used by wdl_pipeline_from_git.yaml)

### DIFF
--- a/wdl_runner/cromwell_launcher/setup.sh
+++ b/wdl_runner/cromwell_launcher/setup.sh
@@ -69,7 +69,7 @@ if [[ ! -e /root/google-cloud-sdk ]]; then
   retry_cmd 'curl https://sdk.cloud.google.com | bash'
 fi
 
-# Add the install location explicity to the path (for non-interactive shells)
+# Add the install location explicitly to the path (for non-interactive shells)
 export PATH=/root/google-cloud-sdk/bin:$PATH
 
 # Install pip for the next two steps...

--- a/wdl_runner/workflows/common/basic.jes.us.options.json
+++ b/wdl_runner/workflows/common/basic.jes.us.options.json
@@ -1,6 +1,6 @@
 {
   "defaultRuntimeOptions": {
-    "zones": "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d"
+    "zones": "us-central1-a us-central1-b us-central1-c us-central1-f us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b" 
   }
 }
 

--- a/wdl_runner/workflows/wdl_pipeline_from_git.yaml
+++ b/wdl_runner/workflows/wdl_pipeline_from_git.yaml
@@ -20,15 +20,17 @@ inputParameters:
 docker:
   imageName: java:openjdk-8-jre
 
-  # The command passed to docker below creates a directory for the
-  # source code and pulls it from a git repository.
-  # To pull from git, we need to install the git client.
+  cmd: |
+    # The command passed to docker below creates a directory for the
+    # source code and pulls it from a git repository.
+    # To pull from git, we need to install the git client.
 
-  cmd: >
-    apt-get update && apt-get install --yes git &&
+    set -o errexit
+    set -o nounset
 
-    git clone "${GIT_SOURCE_URL}" /repo &&
-    cd /repo/wdl_runner/cromwell_launcher && source setup.sh &&
+    apt-get update && apt-get install --yes git
+
+    git clone "${GIT_SOURCE_URL}" /repo
+    cd /repo/wdl_runner/cromwell_launcher && source setup.sh
 
     /wdl_runner/wdl_runner.sh
-


### PR DESCRIPTION
Makes setup.sh more robust to network or server failures.
Reformats the docker command in wdl_pipeline_from_git.yaml to demonstrate how to more cleanly implement a multi-line "command".
Adds us-west zones to the basic.jes.us.options.json.
