### PR TITLE
wdl_runner: monitor, tests, latest Cromwell release

### DIFF
--- a/samtools/README.md
+++ b/samtools/README.md
@@ -91,7 +91,7 @@ Running: [operations/YOUR-NEW-OPERATION-ID]
 This github repo includes a shell script, [../tools/poll.sh](../tools/poll.sh), for monitoring the completion status of an operation.
 
 ```
-$../tools/poll.sh YOUR-NEW-OPERATION-ID
+$ ../tools/poll.sh YOUR-NEW-OPERATION-ID 20
 Operation not complete. Sleeping 20 seconds
 Operation not complete. Sleeping 20 seconds
 ...
@@ -100,14 +100,20 @@ Operation not complete. Sleeping 20 seconds
 Operation complete
 done: true
 metadata:
-  '@type': type.googleapis.com/google.genomics.v1.OperationMetadata
-  clientId: ''
-  createTime: '2016-05-04T17:21:07.000Z'
-  endTime: '2016-05-04T17:22:34.000Z'
-...
-  startTime: '2016-05-04T17:21:36.000Z'
+  events:
+  - description: start
+    startTime: '2016-05-04T17:22:16.258279445Z'
+  - description: pulling-image
+    startTime: '2016-05-04T17:22:16.258324967Z'
+  - description: localizing-files
+    startTime: '2016-05-04T17:22:27.650908389Z'
+  - description: running-docker
+    startTime: '2016-05-04T17:22:30.615818360Z'
+  - description: delocalizing-files
+    startTime: '2016-05-04T17:22:31.100643739Z'
+  - description: ok
+    startTime: '2016-05-04T17:22:34.669517713Z'
 name: operations/YOUR-NEW-OPERATION-ID
-
 ```
 
 ### (4d) Check the results

--- a/tests/wdl_runner/test.README.wdl_pipeline_from_git.sh
+++ b/tests/wdl_runner/test.README.wdl_pipeline_from_git.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# test.README.wdl_pipeline_from_git.sh
+#
+# Tests the sample pipeline in the wdl_runner/README.md file which is launched
+# using wdl_pipeline_from_git.yaml:
+#
+# 1- Launch the operation
+# 2- Poll for completion
+# 3- Check the results
+#
+# The operation typically takes a bit less than 20 minutes to complete, but
+# this is very dependent on the runtime conditions including:
+#
+# * Compute engine quota available in Cloud project 
+# * Network connectivity, server availability, and download throughput for:
+#   * debian mirrors
+#   * github
+#   * Cloud Storage
+#
+# So we set a 60 minute timeout for the operation. If the timeout occurs,
+# an attempt will be made to kill the operation.
+
+# Assume the following are set:
+#  YOUR_BUCKET
+
+set -o errexit
+set -o nounset
+
+readonly SCRIPT_DIR=$(dirname "${0}")
+readonly REPO_ROOT=$(readlink -f ${SCRIPT_DIR}/../../)
+
+# Launch the script from the wdl_runner directory (as the README indicates)
+cd ${REPO_ROOT}/wdl_runner
+
+readonly LOGGING="gs://${YOUR_BUCKET}/pipelines-api-examples/wdl_runner/logging"
+readonly OUTPUTS="gs://${YOUR_BUCKET}/pipelines-api-examples/wdl_runner/output"
+readonly WORKSPACE="gs://${YOUR_BUCKET}/pipelines-api-examples/wdl_runner/workspace"
+
+# Don't launch the test if the output or workspace paths already exist
+echo "Checking if workspace directory exists"
+if gsutil ls ${WORKSPACE} 2>/dev/null; then
+  2>&1 echo "WORKSPACE path exists: ${WORKSPACE}"
+  2>&1 echo "Remove contents and rerun."
+  exit 1
+fi
+echo "Checking if output directory exists"
+if gsutil ls ${OUTPUTS} 2>/dev/null; then
+  2>&1 echo "Output path exists: ${OUTPUTS}"
+  2>&1 echo "Remove contents and rerun."
+  exit 1
+fi
+
+# 1- Launch the operation
+readonly OPERATION_ID=$(\
+  gcloud \
+    alpha genomics pipelines run \
+    --pipeline-file workflows/wdl_pipeline_from_git.yaml \
+    --zones us-east1-d \
+    --logging "${LOGGING}" \
+    --inputs-from-file WDL=workflows/vcf_chr_count/vcf_chr_count.wdl \
+    --inputs-from-file WORKFLOW_INPUTS=workflows/vcf_chr_count/vcf_chr_count.sample.inputs.json \
+    --inputs-from-file WORKFLOW_OPTIONS=workflows/common/basic.jes.us.options.json \
+    --inputs WORKSPACE="${WORKSPACE}" \
+    --inputs OUTPUTS="${OUTPUTS}" \
+    --format 'value(name)'
+)
+
+echo "Started operation ${OPERATION_ID}"
+
+# 2- Poll for completion
+readonly MONITOR_SH="${REPO_ROOT}/wdl_runner/tools/monitor_wdl_pipeline.sh"
+readonly MONITOR_INTERVAL=60
+readonly MONITOR_MAX=$((60 * 60))
+if ! "${MONITOR_SH}" \
+        "${OPERATION_ID}" "${MONITOR_INTERVAL}" "${MONITOR_MAX}"; then
+  gcloud --quiet alpha genomics operations cancel "${OPERATION_ID}"
+  exit 1
+fi
+
+# 3- Check the results
+readonly RESULT_EXPECTED=$(cat <<EOF
+chrM.vcf 197
+chrX.vcf 4598814
+chrY.vcf 653100
+EOF
+)
+
+readonly RESULT=$(gsutil cat "${OUTPUTS}"/output.txt)
+if ! diff <(echo "${RESULT_EXPECTED}") <(echo "${RESULT}"); then
+  echo "Output file does not match expected"
+  exit 1
+fi
+
+echo
+echo "Output file matches expected:"
+echo "*****************************"
+echo "${RESULT}"
+echo "*****************************"

--- a/tools/get_yaml_value.py
+++ b/tools/get_yaml_value.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# get_yaml_value.py
+#
+# Utility script for extracting values from YAML.
+# This will typically be called from shell scripts, which typically
+# have fairly hacky ways of extracting values from YAML.
+#
+# An example usage would be where a shell script has YAML output from
+# a gcloud command for an genomics operation and needs to extract fields:
+#
+#  OP=$(gcloud --format=yaml alpha genomics operations describe "${OP_ID}")
+#  CTIME=$(python tools/get_yaml_value.py "${OP}" "metadata.createTime")
+#  ETIME=$(python tools/get_yaml_value.py "${OP}" "metadata.endTime")
+#
+# Note that gcloud directly supports extracting fields, so the above could also
+# be:
+#
+#  CTIME=$(gcloud alpha genomics operations describe "${OP_ID}"
+#           --format='value(metadata.createTime)')
+#  ETIME=$(gcloud alpha genomics operations describe "${OP_ID}"
+#          --format='value(metadata.endTime)')
+#
+# but then requires an API calls to get each value.
+#
+# Note that if the value requested does not exist in the YAML, this script
+# exits with an error code (1).
+
+from __future__ import print_function
+
+import sys
+import yaml
+
+if len(sys.argv) != 3:
+  print("Usage: %s [yaml] [field]" % sys.argv[0], file=sys.stderr)
+  sys.exit(1)
+
+def main(yaml_string, field):
+  data = yaml.load(yaml_string)
+
+  # field is expected to be period-separated: foo.bar.baz
+  fields = field.split('.')
+
+  # Walk the list of fields and check that the key exists.
+  curr = data
+  for key in fields:
+    if key in curr:
+      curr = curr[key]
+    else:
+      sys.exit(1)
+  
+  print(curr)
+
+if __name__ == '__main__':
+  main(sys.argv[1], sys.argv[2])

--- a/tools/operations_util.sh
+++ b/tools/operations_util.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# operations_util.sh
+
+# get_operation_done_status
+#
+# Request just the value of the operation top-level "done" field.
+# Returns the value in all lower-case.
+function get_operation_done_status() {
+  local operation_id="${1}"
+
+  gcloud alpha genomics operations describe ${operation_id} \
+      --format='value(done)' \
+    | tr 'A-Z' 'a-z'
+}
+readonly -f get_operation_done_status
+
+# get_operation_status
+#
+# Return basic status information about the pipeline:
+#
+#  * done
+#  * error
+#  * metadata.events
+#  * name
+#
+function get_operation_status() {
+  local operation_id="${1}"
+
+  gcloud alpha genomics operations describe ${operation_id} \
+    --format='yaml(done, error, metadata.events, name)'
+}
+readonly -f get_operation_status
+
+# get_operation_compute_resources
+#
+# Return the Compute Engine resources for the operation (if present)
+#
+function get_operation_compute_resources() {
+  local operation_id="${1}"
+
+  gcloud alpha genomics operations describe ${operation_id} \
+    --format='yaml(metadata.runtimeMetadata.computeEngine)'
+}
+readonly -f get_operation_compute_resources
+
+# get_operation_all
+#
+# Requests the full details of the operation in YAML format
+function get_operation_all() {
+  local operation_id="${1}"
+
+  gcloud alpha genomics operations describe ${operation_id} \
+    --format yaml
+}
+readonly -f get_operation_all
+

--- a/wdl_runner/README.md
+++ b/wdl_runner/README.md
@@ -163,25 +163,87 @@ The output will be an operation ID for the Pipeline.
 
 ## (3) Monitor the pipeline operation
 
-This github repo includes a shell script, [../tools/poll.sh](../tools/poll.sh), for monitoring the completion status of an operation.
+This github repo includes a shell script,
+[./tools/monitor_wdl_pipelines.sh](./tools/monitor_wdl_pipelines.sh),
+for monitoring the status of a pipeline launched using the
+``wdl_pipeline.yaml`` or ``wdl_pipeline_from_git.yaml`` files.
 
 ```
-$../tools/poll.sh YOUR-NEW-OPERATION-ID
-Operation not complete. Sleeping 20 seconds
-Operation not complete. Sleeping 20 seconds
-...
-Operation not complete. Sleeping 20 seconds
+$ ./tools/monitor_wdl_pipeline.sh YOUR-NEW-OPERATION-ID
+Logging: gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/logging
+Workspace: gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/workspace
+Outputs: gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output
 
-Operation complete
-done: true
-metadata:
-  '@type': type.googleapis.com/google.genomics.v1.OperationMetadata
-  clientId: ''
-  createTime: '2016-06-23T18:22:31.000Z'
-  endTime: '2016-06-23T18:41:18.000Z'
+2016-09-01 09:37:44: operation not complete
+No operations logs found.
+There are 0 output files
+Sleeping 60 seconds
+
 ...
-  startTime: '2016-06-23T18:22:42.000Z'
-name: operations/YOUR-NEW-OPERATION-ID
+
+2016-09-01 09:40:53: operation not complete
+Calls started but not complete:
+  call-vcf_split
+Sleeping 60 seconds
+
+...
+
+2016-09-01 09:44:02: operation not complete
+Operation logs found: 
+  YOUR-NEW-OPERATION-ID.log
+  YOUR-NEW-OPERATION-ID.log
+  YOUR-NEW-OPERATION-ID
+Calls (including shards) completed: 1
+Calls started but not complete:
+  call-vcf_record_count/shard-0
+  call-vcf_record_count/shard-1
+  call-vcf_record_count/shard-2
+Sleeping 60 seconds
+
+...
+
+2016-09-01 09:54:31: operation not complete
+Calls (including shards) completed: 4
+No calls currently in progress.
+  (Transitioning to next stage or copying final output).
+Sleeping 60 seconds
+
+2016-09-01 09:55:34: operation not complete
+Calls (including shards) completed: 4
+Calls started but not complete:
+  call-gather
+Sleeping 60 seconds
+
+2016-09-01 09:56:37: operation not complete
+Calls (including shards) completed: 5
+No calls currently in progress.
+  (Transitioning to next stage or copying final output).
+There are 1 output files
+Sleeping 60 seconds
+
+2016-09-01 09:57:40: operation complete
+Completed operation status information
+  done: true
+  metadata:
+    events:
+    - description: start
+      startTime: '2016-09-01T16:38:18.215458712Z'
+    - description: pulling-image
+      startTime: '2016-09-01T16:38:18.215809129Z'
+    - description: localizing-files
+      startTime: '2016-09-01T16:38:42.613937060Z'
+    - description: running-docker
+      startTime: '2016-09-01T16:38:42.613978300Z'
+    - description: delocalizing-files
+      startTime: '2016-09-01T16:56:42.144127783Z'
+    - description: ok
+      startTime: '2016-09-01T16:56:43.725128719Z'
+  name: operations/YOUR-NEW-OPERATION-ID
+  gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output/output.txt
+  gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output/wdl_run_metadata.json
+
+Preemptions:
+  None
 ```
 
 ## (4) Check the results
@@ -193,9 +255,10 @@ If none, then the operation should have finished successfully.
 
 ```
 $ gsutil ls -l gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output
-        46  2016-06-23T18:41:14Z  gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output/output.txt
-     12979  2016-06-23T18:41:11Z  gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output/wdl_run_metadata.json
 TOTAL: 2 objects, 13025 bytes (12.72 KiB)
+        46  2016-09-01T16:56:40Z  gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output/output.txt
+     15069  2016-09-01T16:56:37Z  gs://YOUR-BUCKET/pipelines-api-examples/wdl_runner/output/wdl_run_metadata.json
+TOTAL: 2 objects, 15115 bytes (14.76 KiB)
 ```
 
 * Replace `YOUR-BUCKET` with a bucket in your project.

--- a/wdl_runner/cromwell_launcher/Dockerfile
+++ b/wdl_runner/cromwell_launcher/Dockerfile
@@ -56,8 +56,8 @@ RUN chmod u+x /wdl_runner/wdl_runner.sh
 # Copy Cromwell and the Cromwell conf template
 RUN mkdir /cromwell
 RUN cd /cromwell && \
-    curl -L -O https://github.com/broadinstitute/cromwell/releases/download/0.19/cromwell-0.19.jar
-RUN ln /cromwell/cromwell-0.19.jar /cromwell/cromwell.jar
+    curl -L -O https://github.com/broadinstitute/cromwell/releases/download/0.19.3/cromwell-0.19.3.jar
+RUN ln /cromwell/cromwell-0.19.3.jar /cromwell/cromwell.jar
 COPY jes_template.conf /cromwell/
 
 # Set up the runtime environment

--- a/wdl_runner/cromwell_launcher/setup.sh
+++ b/wdl_runner/cromwell_launcher/setup.sh
@@ -101,8 +101,8 @@ chmod u+x /wdl_runner/wdl_runner.sh
 # Copy Cromwell and the Cromwell conf template
 mkdir /cromwell
 (cd /cromwell && \
-    retry_cmd 'curl -L -O https://github.com/broadinstitute/cromwell/releases/download/0.19/cromwell-0.19.jar')
-ln /cromwell/cromwell-0.19.jar /cromwell/cromwell.jar
+    retry_cmd 'curl -L -O https://github.com/broadinstitute/cromwell/releases/download/0.19.3/cromwell-0.19.3.jar')
+ln /cromwell/cromwell-0.19.3.jar /cromwell/cromwell.jar
 cp jes_template.conf /cromwell/
 
 # Set up the runtime environment

--- a/wdl_runner/tools/monitor_wdl_pipeline.sh
+++ b/wdl_runner/tools/monitor_wdl_pipeline.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# monitor_wdl_pipeline.sh
+#
+# Simple script that can be used to monitor the status of a WDL pipeline
+# launched using workflows/wdl_pipeline.sh or workflows/wdl_pipeline_from_git.sh
+# and run by the Broad's Cromwell (https://github.com/broadinstitute/cromwell).
+#
+# The script accepts an operation ID for a pipeline, extracts the
+# LOGGING, WORKSPACE, and OUTPUT directories from the operation and then
+# examines these directories to glean some insights into the status of the
+# operation.
+#
+# Note: if the WORKSPACE and/or OUTPUT directories for the specified operation
+#       are already populated (for example by another operation), this script
+#       will emit incorrect output.
+
+set -o errexit
+set -o nounset
+
+readonly SCRIPT_DIR=$(dirname "${0}")
+readonly REPO_ROOT=$(readlink -f ${SCRIPT_DIR}/../../)
+
+# Bring in polling utility functions
+source ${REPO_ROOT}/tools/operations_util.sh
+
+# FUNCTIONS
+
+# get_yaml_value
+#
+# Wrapper around the get_yaml_value.py script to extract values from
+# a YAML string.
+function get_yaml_value() {
+  python ${REPO_ROOT}/tools/get_yaml_value.py "${1}" "${2}"
+}
+readonly -f get_yaml_value
+
+# gsutil_ls
+#
+# Run "gsutil ls" masking stderr output and the non-zero exit code
+function gsutil_ls() {
+  gsutil ls $* 2>/dev/null || true
+}
+readonly -f gsutil_ls
+
+# line_count
+#
+# Emit the number of lines of text in a string.
+function line_count() {
+  local lines="${1}"
+  if [[ -z "${lines}" ]]; then
+    echo "0"
+  else
+    echo "${lines}" | wc -l
+  fi
+}
+readonly line_count
+
+# indent
+#
+# Indent stdin two spaces
+function indent() {
+  sed -e 's#^#  #'
+}
+readonly -f indent
+
+# MAIN
+
+if [[ $# -lt 1 ]]; then
+  2>&1 echo "Usage: $0 OPERATION-ID <poll-interval>"
+  exit 1
+fi
+
+readonly OPERATION_ID="${1}"
+readonly POLL_INTERVAL_SECONDS="${2:-60}"  # Default: 60 seconds between requests
+readonly POLL_WAIT_MAX="${3:-}"            # Default: wait forever
+
+# Get GCS paths from the operation
+OPERATION=$(get_operation_all ${OPERATION_ID})
+LOGGING=$(get_yaml_value "${OPERATION}" \
+            "metadata.request.pipelineArgs.logging.gcsPath")
+WORKSPACE=$(get_yaml_value "${OPERATION}" \
+            "metadata.request.pipelineArgs.inputs.WORKSPACE")
+OUTPUTS=$(get_yaml_value "${OPERATION}" \
+            "metadata.request.pipelineArgs.inputs.OUTPUTS")
+
+echo "Logging: ${LOGGING}"
+echo "Workspace: ${WORKSPACE}"
+echo "Outputs: ${OUTPUTS}"
+
+# Loop until operation complete or POLL_WAIT_MAX
+POLL_WAIT_TOTAL=0
+LOGS_COUNT=-1
+PREEMPT_COUNT=-1
+OUTPUT_COUNT=-1
+while [[ $(get_operation_done_status "${OPERATION_ID}") == "false" ]]; do
+
+  echo
+  echo "$(date '+%Y-%m-%d %H:%M:%S'): operation not complete"
+
+  # Check that we haven't been polling too long
+  if [[ -n "${POLL_WAIT_MAX}" ]] && \
+     [[ "${POLL_WAIT_TOTAL}" -ge "${POLL_WAIT_MAX}" ]]; then
+    echo "Total wait time (${POLL_WAIT_TOTAL} seconds) has exceeded the max (${POLL_WAIT_MAX})."
+    exit 2
+  fi
+
+  # Gather info. These directories can be empty for a while during execution
+
+  # Logs should be 0 to 3 files and should be the first to show up
+  GS_LOGS=$(gsutil_ls "${LOGGING}/${OPERATION_ID#operations/}*")
+  GS_WS=$(gsutil_ls "${WORKSPACE}/**" | sed -e 's#^'${WORKSPACE}/'##')
+  GS_OUT=$(gsutil_ls "${OUTPUTS}")
+
+  # The Cromwell filesystem is going to be:
+  #   <workspace>/<workflow-name>/<cromwell-job-id>/call-<stage>
+  # with some variety to what is under each "call-<stage>"
+  #
+  # If the call is unsharded (not a scatter), then the call-<stage>
+  # directory contains objects like:
+  #   exec.sh -- The code that gets executed on the VM.
+  #   <stage>-rc.txt -- Contains the return code for the stage.
+  #                     This file will not be exist until the stage completes.
+  #                     If the VM is preempted, this file will never be written.
+  #   <stage>-stdout.txt -- stdout captured during execution of exec.sh.
+  #   <stage>-stderr.txt -- stderr captured during execution of exec.sh.
+  #   <stage>.txt -- Genomics Pipeliens operations log.
+  #
+  # If the stage is sharded, then for each shard there will be a folder under
+  # call-<stage> named "shard-<n>" where numbering starts at 0.
+  #
+  # If the Pipelines VM was preempted, then a subdirectory will be found under
+  # call-<stage> named "attempt-<m>" where numbering starts at 2.
+  #
+  # For sharded and preemptible stages then, one may find:
+  # call-<stage>/shard-<n>/attempt-<m>
+
+  # From the list of the files in the workspace directory, extract useful
+  # sets of files from which we can glean status:
+  # All "exec.sh" files: indicates that the call and/or shard and/or attempt
+  #   has started.
+  # All "-rc.txt" files: indicates that the call and/or shard and/or attempt
+  #   has completed.
+  # All "attempt-*/exec.sh" files: indicates that a previous attempt failed
+  #   and is assume to be due to preemption (*this is *not* checked explicitly).
+
+  WS_EXECS=$(echo "${GS_WS}" | grep '/exec.sh$' || true)
+  WS_RCS=$(echo "${GS_WS}" | grep '\-rc.txt$' || true)
+  WS_PREEMPTS=$(echo "${GS_WS}" | grep 'attempt-[0-9]\+/exec.sh$' || true)
+
+  # Emit status
+
+  GS_LOGS_COUNT=$(line_count "${GS_LOGS}")
+  if [[ "${GS_LOGS_COUNT}" -ne "${LOGS_COUNT}" ]]; then
+    if [[ -n "${GS_LOGS}" ]]; then
+      echo "Operation logs found: "
+      echo "${GS_LOGS}" | sed -e 's#^'${LOGGING}/'##g' | indent
+    else
+      echo "No operations logs found."
+    fi
+    LOGS_COUNT="${GS_LOGS_COUNT}"
+  fi
+
+  if [[ -n "${WS_EXECS}" ]]; then
+    if [[ -n "${WS_RCS}" ]]; then
+      echo "Calls (including shards) completed: "$(line_count "${WS_RCS}")
+    fi
+
+    # To determine what is running, find all call or call/shard paths that
+    # have an "exec.sh" with no "*-rc.txt" file.
+    WS_CALLS_STARTED=$(
+      echo "${WS_EXECS}" \
+        | sed -e 's#[^/]\+/[^/]\+/##' \
+              -e 's#/exec.sh##' \
+              -e 's#/attempt-[0-9]\+##' \
+        | sort -u)
+    WS_CALLS_COMPLETE=$(
+      echo "${WS_RCS}" \
+        | sed -e 's#[^/]\+/[^/]\+/##' \
+              -e 's#/[^/]\+-rc.txt##' \
+              -e 's#/attempt-[0-9]\+##' \
+        | sort -u)
+
+    IN_PROGRESS=$(\
+      comm -2 -3  \
+        <(echo "${WS_CALLS_STARTED}") \
+        <(echo "${WS_CALLS_COMPLETE}"))
+    if [[ -n ${IN_PROGRESS} ]]; then
+      echo "Calls started but not complete:"
+      echo "${IN_PROGRESS}" | indent
+    else
+      echo "No calls currently in progress."
+      echo "(Transitioning to next stage or copying final output)." | indent
+    fi
+
+    WS_PREEMPT_COUNT=$(line_count "${WS_PREEMPTS}")
+    if [[ "${WS_PREEMPT_COUNT}" -ne "${PREEMPT_COUNT}" ]]; then
+      echo "Total Preemptions: ${WS_PREEMPT_COUNT}"
+      PREEMPT_COUNT="${WS_PREEMPT_COUNT}"
+    fi
+  fi
+
+  GS_OUTPUT_COUNT=$(line_count "${GS_OUT}")
+  if [[ "${GS_OUTPUT_COUNT}" -ne "${OUTPUT_COUNT}" ]]; then
+    echo "There are ${GS_OUTPUT_COUNT} output files"
+
+    OUTPUT_COUNT="${GS_OUTPUT_COUNT}"
+  fi
+
+  echo "Sleeping ${POLL_INTERVAL_SECONDS} seconds"
+  sleep ${POLL_INTERVAL_SECONDS}
+  POLL_WAIT_TOTAL=$((POLL_WAIT_TOTAL + POLL_INTERVAL_SECONDS))
+done
+
+echo
+echo "$(date '+%Y-%m-%d %H:%M:%S'): operation complete"
+
+echo "Completed operation status information"
+get_operation_status "${OPERATION_ID}" | indent
+
+echo "Operation output"
+gsutil_ls "${OUTPUTS}" | indent
+
+echo
+echo "Preemption retries:"
+WS_PREEMPTS=$(gsutil_ls ${WORKSPACE}/**/attempt-*/exec.sh)
+if [[ -n "${WS_PREEMPTS}" ]]; then
+  echo "${WS_PREEMPTS}" \
+    | sed -e 's#^'${WORKSPACE}'/[^/]\+/[^/]\+/##' \
+          -e 's#/exec.sh##' \
+    | indent
+
+  echo "Total preemptions: " $(echo "${WS_PREEMPTS}" | wc -l)
+else
+  echo "None" | indent
+fi


### PR DESCRIPTION
Add wdl_runner/tools/monitor_wdl_pipeline.sh which can give some useful
insight into a running workflow.
Add test/tests/wdl_runner/test.README.wdl_pipeline_from_git.sh to make it
easy to test one of the examples from the README.
Update Dockerfile and setup.sh to pick up Cromwell 0.19.3.

Also modified poll.sh:
  * Default interval is now 60 seconds instead of 20
  * Default completed operation output is brief