### PR TITLE
wdl_runner: install of git needs to be retried

### DIFF
--- a/wdl_runner/cromwell_launcher/setup.sh
+++ b/wdl_runner/cromwell_launcher/setup.sh
@@ -36,8 +36,8 @@ readonly RETRY_MAX_SECONDS=${SETUP_RETRY_MAX_SECONDS:-5*60}
 # availability is vulnerable to intermittent failure.
 #
 # This function will sleep a designated interval between failures
-# (wait_seconds).
-# The aggregated sleep time is capped at a designated maximum (max_attempts).
+# (retry_interval).
+# The aggregated sleep time is capped at a designated maximum (retry_max).
 function retry_cmd () {
   local cmd="${1}"
   local retry_interval="${2:-${RETRY_INTERVAL_SECONDS}}"

--- a/wdl_runner/cromwell_launcher/setup.sh
+++ b/wdl_runner/cromwell_launcher/setup.sh
@@ -20,53 +20,7 @@
 set -o errexit
 set -o nounset
 
-# Caller of the setup script can configure the extent to which any
-# single setup command will be retried on failure by setting the
-# environment variables:
-#
-#  SETUP_RETRY_INTERVAL_SECONDS (default 10)
-#  SETUP_RETRY_MAX_SECONDS      (default 300)
-#
-readonly RETRY_INTERVAL_SECONDS=${SETUP_RETRY_INTERVAL_SECONDS:-10}
-readonly RETRY_MAX_SECONDS=${SETUP_RETRY_MAX_SECONDS:-5*60}
-
-# retry_cmd
-#
-# Any operation that is dependent on internet connectivity and server
-# availability is vulnerable to intermittent failure.
-#
-# This function will sleep a designated interval between failures
-# (retry_interval).
-# The aggregated sleep time is capped at a designated maximum (retry_max).
-function retry_cmd () {
-  local cmd="${1}"
-  local retry_interval="${2:-${RETRY_INTERVAL_SECONDS}}"
-  local retry_max="${3:-${RETRY_MAX_SECONDS}}"
-
-  echo "RUNNING: ${cmd}"
-  echo
-
-  retry_time=0
-  while ((retry_time < retry_max)); do
-    if eval "${cmd}"; then
-      echo
-      echo "SUCCEEDED: ${cmd}"
-
-      return
-    fi
-
-    if ((retry_time < retry_max)); then
-      echo "SLEEP: ${retry_interval} seconds before retrying"
-      sleep ${retry_interval}
-      ((retry_time+=retry_interval))
-    fi
-  done
-
-  echo "Total retry time (${retry_time}) reached max ($((retry_max))) seconds"
-  echo "FAILED: ${cmd}"
-  exit 1
-}
-readonly -f retry_cmd
+# Caller must have provided a shell function or command "retry_cmd".
 
 # Assumes: FROM java:openjdk-8-jre
 

--- a/wdl_runner/workflows/wdl_pipeline_from_git.yaml
+++ b/wdl_runner/workflows/wdl_pipeline_from_git.yaml
@@ -20,9 +20,9 @@ inputParameters:
   defaultValue: master
 
 - name: SETUP_RETRY_INTERVAL_SECONDS
-  defaultValue: 30
+  defaultValue: "30"
 - name: SETUP_RETRY_MAX_SECONDS
-  defaultValue: 8*60
+  defaultValue: "5*60"
 
 docker:
   imageName: java:openjdk-8-jre
@@ -35,7 +35,42 @@ docker:
     set -o errexit
     set -o nounset
 
-    apt-get update && apt-get install --yes git
+    # retry_cmd
+    #
+    # This function will sleep a designated interval between failures.
+    # The aggregated sleep time is capped at a designated maximum.
+    function retry_cmd () {
+      local cmd="${1}"
+      local retry_interval="${2:-${SETUP_RETRY_INTERVAL_SECONDS}}"
+      local retry_max="${3:-${SETUP_RETRY_MAX_SECONDS}}"
+
+      echo "RUNNING: ${cmd}" && echo
+
+      retry_time=0
+      while ((retry_time < retry_max)); do
+        if eval "${cmd}"; then
+          echo && echo "SUCCEEDED: ${cmd}"
+          return
+        fi
+
+        if ((retry_time < retry_max)); then
+          echo "SLEEP: ${retry_interval} seconds before retrying"
+          sleep ${retry_interval}
+          ((retry_time+=retry_interval))
+        fi
+      done
+
+      echo "Total retry time (${retry_time}) reached max ($((retry_max)))"
+      echo "FAILED: ${cmd}"
+      exit 1
+    }
+
+    # Export the retry_cmd function to subshells (notably setup.sh)
+    export -f retry_cmd
+
+    # MAIN
+
+    retry_cmd 'apt-get update && apt-get install --yes git'
 
     git clone "${GIT_SOURCE_URL}" /repo
     cd /repo && git checkout ${GIT_BRANCH}

--- a/wdl_runner/workflows/wdl_pipeline_from_git.yaml
+++ b/wdl_runner/workflows/wdl_pipeline_from_git.yaml
@@ -19,6 +19,11 @@ inputParameters:
 - name: GIT_BRANCH
   defaultValue: master
 
+- name: SETUP_RETRY_INTERVAL_SECONDS
+  defaultValue: 30
+- name: SETUP_RETRY_MAX_SECONDS
+  defaultValue: 8*60
+
 docker:
   imageName: java:openjdk-8-jre
 


### PR DESCRIPTION
Moved the retry_cmd into wdl_pipelines_from_git.yaml (from setup.sh).
Added input parameters for the sleep interval and maximum retry time.