### PR TITLE
Cromwell 0.24

### DIFF
--- a/wdl_runner/cromwell_launcher/Dockerfile
+++ b/wdl_runner/cromwell_launcher/Dockerfile
@@ -34,6 +34,9 @@ RUN apt-get update && \
 # Install Python "requests" (for cromwell_driver.py) package
 RUN pip install requests
 
+# Install Python "simplejson" (for file_util.py) package
+RUN pip install simplejson
+
 # Install Google Python client (for file_util.py) package
 RUN pip install --upgrade google-api-python-client
 
@@ -56,8 +59,8 @@ RUN chmod u+x /wdl_runner/wdl_runner.sh
 # Copy Cromwell and the Cromwell conf template
 RUN mkdir /cromwell
 RUN cd /cromwell && \
-    curl -L -O https://github.com/broadinstitute/cromwell/releases/download/0.19.3/cromwell-0.19.3.jar
-RUN ln /cromwell/cromwell-0.19.3.jar /cromwell/cromwell.jar
+    curl -L -O https://github.com/broadinstitute/cromwell/releases/download/24/cromwell-24.jar
+RUN ln /cromwell/cromwell-24.jar /cromwell/cromwell.jar
 COPY jes_template.conf /cromwell/
 
 # Set up the runtime environment

--- a/wdl_runner/cromwell_launcher/cromwell_driver.py
+++ b/wdl_runner/cromwell_launcher/cromwell_driver.py
@@ -141,11 +141,11 @@ class CromwellDriver(object):
       status = status_json['status']
       if status == 'Succeeded':
         break
-      elif status == 'Running':
+      elif status == 'Submitted' or status == 'Running':
         pass
       else:
         sys_util.exit_with_error(
-            "Status of job is not Running or Succeeded: %s" % status)
+            "Status of job is not Submitted or Running or Succeeded: %s" % status)
 
     logging.info("Cromwell job status: %s", status)
 

--- a/wdl_runner/cromwell_launcher/jes_template.conf
+++ b/wdl_runner/cromwell_launcher/jes_template.conf
@@ -21,31 +21,24 @@ spray.can {
 }
 
 backend {
-  defaultBackend = "JES"
-  backendsAllowed = [ "JES" ]
-
-  jes {
-    project = "${project_id}"
-    baseExecutionBucket = "${working_dir}"
-    endpointUrl = "https://genomics.googleapis.com/"
-    maximumPollingInterval = 600
-  }
-}
-
-google {
-  applicationName = "cromwell"
-  cromwellAuthenticationScheme = "application_default"
-}
-
-database {
-  config = main.hsqldb
-
-  main {
-    hsqldb {
-      db.url = "jdbc:hsqldb:mem:${slick.uniqueSchema};shutdown=false;hsqldb.tx=mvcc"
-      db.driver = "org.hsqldb.jdbcDriver"
-      db.connectionTimeout = 1000
-      driver = "slick.driver.HsqldbDriver$"
+  default = "JES"
+  providers {
+    JES {
+      actor-factory = "cromwell.backend.impl.jes.JesBackendLifecycleActorFactory"
+      config {
+        project = "${project_id}"
+        root = "${working_dir}"
+        maximum-polling-interval = 600
+        genomics {
+          auth = "application-default"
+          endpoint-url = "https://genomics.googleapis.com/"
+        }
+        filesystems = {
+          gcs {
+            auth = "application-default"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Updating Cromwell launcher container image to support latest 0.24 upstream release.

Also added accepting `Submitted` in addition to `Running` as a temporary status response from Cromwell. I had a couple of failed executions with this Cromwell response status and the driver assumed a failure.