### PR TITLE
Specify heap space parameters in Cromwell command

### DIFF
--- a/wdl_runner/cromwell_launcher/cromwell_driver.py
+++ b/wdl_runner/cromwell_launcher/cromwell_driver.py
@@ -48,6 +48,7 @@ class CromwellDriver(object):
     self.cromwell_proc = subprocess.Popen([
         'java',
         '-Dconfig.file=' + self.cromwell_conf,
+        '-Xmx4g',
         '-jar', self.cromwell_jar,
         'server'])
 


### PR DESCRIPTION
By default the memory allocation to Cromwell is small, and while this is fine for lightweight workflows, it's not sufficient for big workflows with wide scatters. Combined with using `--memory 2` to request a bigger machine, this prevents Cromwell from dying.

Making the value larger than it strictly needs to be so we can scale up as needed with just the cmdline argument; it doesn't seem to hurt when running small workflows on a smaller machine.