### PR TITLE
wdl_runner: increase default memory requirement

### DIFF
--- a/wdl_runner/workflows/wdl_pipeline.yaml
+++ b/wdl_runner/workflows/wdl_pipeline.yaml
@@ -21,4 +21,4 @@ docker:
     /wdl_runner/wdl_runner.sh
 
 resources:
-  minimumRamGb: 1
+  minimumRamGb: 3.75


### PR DESCRIPTION
 such that an `n1-standard-1` is used instead of a `g1-small`.