### PR TITLE
Handle organization project IDs in imageName

### DIFF
--- a/fastqc/cloud/run_fastqc.py
+++ b/fastqc/cloud/run_fastqc.py
@@ -120,9 +120,10 @@ operation = service.pipelines().run(body={
       } ],
     },
 
-    # Specify the Docker image to use along with the command
+    # Specify the Docker image to use along with the command. Projects IDs with a
+    # colon (:) must swap it for a forward slash when specifying image names.
     'docker': {
-      'imageName': 'gcr.io/%s/fastqc' % args.project,
+      'imageName': 'gcr.io/%s/fastqc' % args.project.replace(':', '/'),
 
       # The Pipelines API will create the input directory when localizing files,
       # but does not create the output directory.


### PR DESCRIPTION
New style project IDs for projects within an organization have colon and look like "example.com/foo-bar". Google container registry requires that the container tags swap the colon for a forward slash (1).  This pull request fixes the issue in the Python workflow runner so that the tutorial requires no code editing for these users.


(1) https://cloud.google.com/container-registry/docs/pushing-and-pulling?hl=en_US&_ga=1.199675625.630068152.1497036730