### PR TITLE
Fixes the input recursive argument

### DIFF
--- a/cwl_runner/cwl_runner.sh
+++ b/cwl_runner/cwl_runner.sh
@@ -83,7 +83,7 @@ while [[ $# -gt 0 ]]; do
     INPUT="$2"
     shift
     ;;
-    -r|--input-recursive)
+    -I|--input-recursive)
     INPUT_RECURSIVE="$2"
     shift
     ;;


### PR DESCRIPTION
The input recursive argument is documented as "-I" but coded as "-r" which just so happens to conflict with the "--runner" argument.